### PR TITLE
Fix goto/href resolve() and each block key lint errors

### DIFF
--- a/client/src/lib/components/LoginLinkDevice.svelte
+++ b/client/src/lib/components/LoginLinkDevice.svelte
@@ -6,6 +6,7 @@
 	import { HubConnectionState } from "@microsoft/signalr";
 	import { signInCustomToken } from "$lib/firebase.svelte";
 	import { goto } from "$app/navigation";
+	import { resolve } from "$app/paths";
 
 	let init = $state(false);
 	let open = $state(false);
@@ -40,7 +41,7 @@
 
 			try {
 				await signInCustomToken(deviceAuthEvent.token);
-				goto("/");
+				goto(resolve("/"));
 			} catch (err) {
 				toast.error("Could not login");
 				console.error(err);

--- a/client/src/routes/(pages)/(salesPeriod)/(backOffice)/Filter.svelte
+++ b/client/src/routes/(pages)/(salesPeriod)/(backOffice)/Filter.svelte
@@ -4,6 +4,7 @@
 	import { Command, Popover, Button, Badge } from "@kayord/ui";
 	import { cn } from "@kayord/ui/utils";
 	import { goto } from "$app/navigation";
+	import { resolve } from "$app/paths";
 	import { page } from "$app/state";
 
 	type Props<TData, TValue> = {
@@ -23,7 +24,7 @@
 	$effect(() => {
 		if (page.params.divisionIds != selected.join(",")) {
 			const ids = selected.length > 0 ? selected.join(",") : "0";
-			const url = isHistory ? `/backOffice/${ids ?? "0"}/history` : `/backOffice/${ids}`;
+			const url = isHistory ? resolve(`/backOffice/${ids}/history`) : resolve(`/backOffice/${ids}`);
 			goto(url, { keepFocus: true });
 		}
 	});
@@ -39,7 +40,7 @@
 						{selected.length}
 					</Badge>
 					<div class="hidden space-x-1 lg:flex">
-						{#each options.filter((opt) => selected.includes(opt.value)) as option}
+						{#each options.filter((opt) => selected.includes(opt.value)) as option (option.value)}
 							<Badge variant="secondary" class="h-4 rounded-sm px-1 py-1 font-normal">
 								{option.label}
 							</Badge>
@@ -55,7 +56,7 @@
 			<Command.List>
 				<Command.Empty>No results found.</Command.Empty>
 				<Command.Group>
-					{#each options as option}
+					{#each options as option (option.value)}
 						{@const isSelected = selected.includes(option.value)}
 						<Command.Item
 							onSelect={() => {

--- a/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/table/basket/[id]/+page.svelte
+++ b/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/table/basket/[id]/+page.svelte
@@ -6,6 +6,7 @@
 	import { ChefHatIcon } from "@lucide/svelte";
 	import { createTableOrderGetBasket, createTableOrderSendToKitchen, createTableOrderUpdateOrderItem } from "$lib/api";
 	import { goto } from "$app/navigation";
+	import { resolve } from "$app/paths";
 	import { page } from "$app/state";
 	import { defaults, superForm } from "sveltekit-superforms/client";
 	import { zod4 } from "sveltekit-superforms/adapters";
@@ -55,7 +56,7 @@
 				},
 			});
 			if (result.isSuccess) {
-				goto(`/table/menu/${page.params.id}`);
+				goto(resolve(`/table/menu/${page.params.id}`));
 			} else {
 				toast.error(result.message);
 				refetch();

--- a/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/table/bill/[id]/Adjustment.svelte
+++ b/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/table/bill/[id]/Adjustment.svelte
@@ -100,7 +100,7 @@
 									{typeSelect}
 								</Select.Trigger>
 								<Select.Content>
-									{#each query.data ?? [] as result}
+									{#each query.data ?? [] as result (result.adjustmentTypeId)}
 										<Select.Item value={result.adjustmentTypeId.toString()}>{result.name}</Select.Item>
 									{/each}
 								</Select.Content>

--- a/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/table/bill/[id]/Bill.svelte
+++ b/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/table/bill/[id]/Bill.svelte
@@ -4,6 +4,7 @@
 	import { toast } from "@kayord/ui/sonner";
 	import { createTableBookingClose, createPayCheck } from "$lib/api";
 	import { goto } from "$app/navigation";
+	import { resolve } from "$app/paths";
 	import Error from "$lib/components/Error.svelte";
 	import { getError } from "$lib/types";
 	import { stringToFDate } from "$lib/util";
@@ -31,7 +32,7 @@
 		try {
 			const result = await closeTableMut.mutateAsync({ data: { tableBookingId: bookingId } });
 			if (result.id) {
-				goto("/waiter");
+				goto(resolve("/waiter"));
 			}
 		} catch (error) {
 			toast.error(getError(error).message);
@@ -106,7 +107,7 @@
 						<span>Adjustments</span>
 						<span></span>
 					</li>
-					{#each data?.adjustments ?? [] as adjustment}
+					{#each data?.adjustments ?? [] as adjustment (adjustment.adjustmentId)}
 						<li class="flex items-center justify-between">
 							<span class="text-muted-foreground">{adjustment.adjustmentType.name}</span>
 							<span>{adjustment.amount.toFixed(2)}</span>
@@ -142,7 +143,7 @@
 			<div class="grid gap-3">
 				<div class="font-semibold">Payments</div>
 				<dl class="grid gap-3">
-					{#each data.paymentsReceived as payment}
+					{#each data.paymentsReceived as payment (payment.id)}
 						<div class="flex items-center justify-between">
 							<div class="text-muted-foreground flex w-full items-center justify-start gap-1">
 								<PaymentTypeIcon type={payment.paymentType.paymentTypeName} />

--- a/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/table/bill/[id]/Item.svelte
+++ b/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/table/bill/[id]/Item.svelte
@@ -10,18 +10,18 @@
 </script>
 
 <Table.Body>
-	{#each data as item}
+	{#each data as item (item.orderItemId)}
 		<Table.Row class="border-none">
 			<Table.Cell class="w-full py-2 font-medium">
 				<div class="line-clamp-1">{item.menuItem.name}</div>
-				{#each item.orderItemOptions ?? [] as option}
+				{#each item.orderItemOptions ?? [] as option (option.orderItemOptionId)}
 					<div class="ml-4 flex items-center gap-1">
 						&gt;
 						<span>{option.option.optionGroup.name}:</span>
 						<span>{option.option.name}</span>
 					</div>
 				{/each}
-				{#each item.orderItemExtras ?? [] as extra}
+				{#each item.orderItemExtras ?? [] as extra (extra.orderItemExtraId)}
 					<div class="ml-4 flex items-center gap-1">
 						+
 						<span class="text-foreground">{extra.extra.extraGroup.name}:</span>
@@ -31,10 +31,10 @@
 			</Table.Cell>
 			<Table.Cell class="w-full py-2 text-right"
 				>{item.menuItem.price.toFixed(2)}
-				{#each item.orderItemOptions ?? [] as option}
+				{#each item.orderItemOptions ?? [] as option (option.orderItemOptionId)}
 					<div>{option.option.price.toFixed(2)}</div>
 				{/each}
-				{#each item.orderItemExtras ?? [] as extra}
+				{#each item.orderItemExtras ?? [] as extra (extra.orderItemExtraId)}
 					<div>{extra.extra.price.toFixed(2)}</div>
 				{/each}
 			</Table.Cell>

--- a/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/table/bill/[id]/Items.svelte
+++ b/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/table/bill/[id]/Items.svelte
@@ -12,7 +12,7 @@
 </script>
 
 <ul class="grid gap-3">
-	{#each data as item}
+	{#each data as item (item.orderItemId)}
 		<li class="flex items-center justify-between">
 			<span class="text-muted-foreground">
 				<!-- {#if showDetail}
@@ -21,14 +21,14 @@
 					</div>
 				{/if} -->
 				<div class="line-clamp-1">{item.quantity} {item.menuItem.name}</div>
-				{#each item.orderItemOptions ?? [] as option}
+				{#each item.orderItemOptions ?? [] as option (option.orderItemOptionId)}
 					<div class="ml-4 flex items-center gap-1">
 						&gt;
 						<span>{option.option.optionGroup.name}:</span>
 						<span>{option.option.name}</span>
 					</div>
 				{/each}
-				{#each item.orderItemExtras ?? [] as extra}
+				{#each item.orderItemExtras ?? [] as extra (extra.orderItemExtraId)}
 					<div class="ml-4 flex items-center gap-1">
 						+
 						<span class="font-light">{extra.extra.extraGroup.name}:</span>
@@ -44,10 +44,10 @@
 					{item.menuItem.price.toFixed(2)}
 					<span class="text-foreground font-semibold">{item.total.toFixed(2)}</span>
 					<div>
-						{#each item.orderItemOptions ?? [] as option}
+						{#each item.orderItemOptions ?? [] as option (option.orderItemOptionId)}
 							<div>{option.option.price.toFixed(2)}</div>
 						{/each}
-						{#each item.orderItemExtras ?? [] as extra}
+						{#each item.orderItemExtras ?? [] as extra (extra.orderItemExtraId)}
 							<div>{extra.extra.price.toFixed(2)}</div>
 						{/each}
 					</div>

--- a/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/table/bill/[id]/actions/email/EmailBill.svelte
+++ b/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/table/bill/[id]/actions/email/EmailBill.svelte
@@ -10,6 +10,7 @@
 	import { page } from "$app/state";
 	import { getError } from "$lib/types";
 	import { goto } from "$app/navigation";
+	import { resolve } from "$app/paths";
 
 	interface Props {
 		bookingId: number;
@@ -19,7 +20,7 @@
 	const mutation = createBillEmailBill();
 
 	const goBack = () => {
-		goto(`/table/bill/${bookingId}`);
+		goto(resolve(`/table/bill/${bookingId}`));
 	};
 
 	const schema = z.object({

--- a/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/table/bill/[id]/actions/print/+page.svelte
+++ b/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/table/bill/[id]/actions/print/+page.svelte
@@ -23,7 +23,7 @@
 			</Alert.Root>
 		{:else}
 			<div class="flex flex-col gap-4">
-				{#each enabledPrinters as printer}
+				{#each enabledPrinters as printer (printer.id)}
 					<Printer {printer} refetch={query.refetch} canPrint={true} />
 				{/each}
 			</div>

--- a/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/table/bill/[id]/actions/whatsapp/+page.svelte
+++ b/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/table/bill/[id]/actions/whatsapp/+page.svelte
@@ -10,6 +10,7 @@
 	import { page } from "$app/state";
 	import { getError } from "$lib/types";
 	import { goto } from "$app/navigation";
+	import { resolve } from "$app/paths";
 	import { CheckIcon, XIcon } from "@lucide/svelte";
 
 	const bookingId = Number(page.params.id);
@@ -20,7 +21,7 @@
 	const canWhatsapp = $derived(query.data?.success ?? false);
 
 	const goBack = () => {
-		goto(`/table/bill/${bookingId}`);
+		goto(resolve(`/table/bill/${bookingId}`));
 	};
 
 	const schema = z.object({

--- a/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/table/menu/[id]/AddMenuItem.svelte
+++ b/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/table/menu/[id]/AddMenuItem.svelte
@@ -128,7 +128,7 @@
 				<h3 class="font-bold">Options</h3>
 			{/if}
 			<Fieldset {form} name="options" class="mt-2">
-				{#each data.menuItemOptionGroups as optionGroup}
+				{#each data.menuItemOptionGroups as optionGroup (optionGroup.optionGroupId)}
 					<Legend>
 						{optionGroup.optionGroup.name}
 						{optionGroup.optionGroup.minSelections > 0 ? "*" : ""} -
@@ -137,7 +137,7 @@
 						</span>
 					</Legend>
 
-					{#each optionGroup.optionGroup.options as option}
+					{#each optionGroup.optionGroup.options as option (option.optionId)}
 						{@const checked = $formData.options.includes(option.optionId)}
 						<div class="flex items-center gap-2 p-1">
 							<Control>
@@ -169,10 +169,10 @@
 			{#if data.menuItemExtraGroups.length > 0}
 				<h3 class="font-bold">Extras</h3>
 			{/if}
-			{#each data.menuItemExtraGroups as extraGroup}
+			{#each data.menuItemExtraGroups as extraGroup (extraGroup.extraGroupId)}
 				<Fieldset {form} name="extras" class="mt-2">
 					<Legend>{extraGroup.extraGroup.name}</Legend>
-					{#each extraGroup.extraGroup.extras as extra}
+					{#each extraGroup.extraGroup.extras as extra (extra.extraId)}
 						{@const checked = $formData.extras.includes(extra.extraId)}
 						<div class="flex items-center gap-2 p-1">
 							<Control>

--- a/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/table/menu/[id]/CategoriesList.svelte
+++ b/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/table/menu/[id]/CategoriesList.svelte
@@ -35,7 +35,7 @@
 							<Breadcrumb.Link>Home</Breadcrumb.Link>
 						</button>
 					</Breadcrumb.Item>
-					{#each sections.parents ?? [] as parent, i}
+					{#each sections.parents ?? [] as parent, i (parent.menuSectionId)}
 						<Breadcrumb.Separator />
 
 						{#if parent.parent}

--- a/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/table/menu/[id]/PickCategory.svelte
+++ b/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/table/menu/[id]/PickCategory.svelte
@@ -56,7 +56,7 @@
 		</Drawer.Header>
 		<div class="mx-auto flex w-full flex-col overflow-auto rounded-t-[10px] px-4">
 			<CategoriesList {sections}>
-				{#each sections?.sections ?? [] as section, i}
+				{#each sections?.sections ?? [] as section, i (section.menuSectionId)}
 					{@const extraClass = section.menuSectionId == menuSection.sectionId ? "bg-primary text-primary-foreground" : ""}
 					<Button onclick={() => setSection(section.menuSectionId)} class={cn("w-full p-2", extraClass)} variant="outline">
 						{section.name}

--- a/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/table/menu/[id]/SpecialExtra.svelte
+++ b/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/table/menu/[id]/SpecialExtra.svelte
@@ -39,7 +39,7 @@
 		<CirclePlusIcon class="mr-2 size-4" /> More Extras
 	</Button>
 	<div class="mt-2 flex flex-wrap gap-2">
-		{#each currentExtras as current}
+		{#each currentExtras as current (current)}
 			<button
 				onclick={(e) => {
 					removeItem(current);
@@ -60,7 +60,7 @@
 	<Command.List>
 		<Command.Empty>No results found.</Command.Empty>
 		<Command.Group heading="Special Extras">
-			{#each query.data ?? [] as extra}
+			{#each query.data ?? [] as extra (extra.extraId)}
 				<Command.Item onSelect={() => selectItem(extra.extraId)} disabled={!extra.isAvailable} class={!extra.isAvailable ? "text-muted" : ""}>
 					<div class="flex w-full flex-row items-center justify-between">
 						<div class="overflow-hidden text-ellipsis whitespace-nowrap">

--- a/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/table/pay/[id]/+page.svelte
+++ b/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/table/pay/[id]/+page.svelte
@@ -8,6 +8,7 @@
 	import { page } from "$app/state";
 	import { createPayManualPayment, createOutletGetPaymentType, payGetLink } from "$lib/api";
 	import { goto } from "$app/navigation";
+	import { resolve } from "$app/paths";
 	import { payment } from "$lib/stores/payment.svelte";
 	import { onMount } from "svelte";
 	import { status } from "$lib/stores/status.svelte";
@@ -42,7 +43,7 @@
 			url = linkResult.value.url;
 			reference = linkResult.value.reference;
 			payment.setUrl(url);
-			goto(`/table/pay/${page.params.id}/${reference}?url=${url}`);
+			goto(resolve(`/table/pay/${page.params.id}/${reference}?url=${url}`));
 		} else {
 			toast.error("Could not start payment");
 		}
@@ -58,7 +59,7 @@
 				paymentTypeId: manualData.paymentTypeId,
 			},
 		});
-		goto(`/table/bill/${page.params.id}`);
+		goto(resolve(`/table/bill/${page.params.id}`));
 	};
 
 	const form = superForm(defaults(zod4(schema)), {
@@ -123,7 +124,7 @@
 								{paymentTypeSelect}
 							</Select.Trigger>
 							<Select.Content>
-								{#each paymentTypeQuery.data ?? [] as paymentType}
+								{#each paymentTypeQuery.data ?? [] as paymentType (paymentType.paymentTypeId)}
 									<Select.Item value={paymentType.paymentTypeId.toString()}>{paymentType.paymentTypeName}</Select.Item>
 								{/each}
 							</Select.Content>

--- a/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/table/pay/[id]/[reference]/+page.svelte
+++ b/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/table/pay/[id]/[reference]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { goto } from "$app/navigation";
+	import { resolve } from "$app/paths";
 	import { page } from "$app/state";
 	import Error from "$lib/components/Error.svelte";
 	import { payment } from "$lib/stores/payment.svelte";
@@ -25,11 +26,11 @@
 	);
 
 	const paymentDone = (amount: number) => {
-		goto(`/table/pay/${page.params.id}/done?amount=${amount}`);
+		goto(resolve(`/table/pay/${page.params.id}/done?amount=${amount}`));
 	};
 
 	const cancelPayment = () => {
-		goto(`/table/bill/${page.params.id}`);
+		goto(resolve(`/table/bill/${page.params.id}`));
 	};
 
 	const paymentCheck = () => {
@@ -43,7 +44,7 @@
 	});
 </script>
 
-<a class="hidden" href="/" bind:this={a}>Halo</a>
+<a class="hidden" href={resolve("/")} bind:this={a}>Halo</a>
 
 <Card.Root class="m-8">
 	<Card.Header class="flex flex-row items-center gap-2">

--- a/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/tables/+page.svelte
+++ b/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/tables/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from "$app/paths";
 	import Error from "$lib/components/Error.svelte";
 
 	import { createTableGetBooked } from "$lib/api";
@@ -28,7 +29,7 @@
 			<p class="text-muted-foreground">Tables assigned to other waiters</p>
 			<div class="mt-4 flex w-full flex-wrap gap-4">
 				{#each query.data as otherTable (otherTable.id)}
-					<a href={`/table/menu/${otherTable.id}`} class="w-full">
+					<a href={resolve(`/table/menu/${otherTable.id}`)} class="w-full">
 						<Card.Root class="w-full gap-1 p-5">
 							<div class="line-clamp-1 flex items-center justify-between gap-2">
 								<h3>{otherTable.table.name}</h3>

--- a/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/tables/book/+page.svelte
+++ b/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/tables/book/+page.svelte
@@ -3,6 +3,7 @@
 	import { toast } from "@kayord/ui/sonner";
 	import { Form } from "@kayord/ui/form";
 	import { goto } from "$app/navigation";
+	import { resolve } from "$app/paths";
 	import Error from "$lib/components/Error.svelte";
 	import { getError } from "$lib/types";
 	import { createTableBookingCreate, createTableGetAvailable } from "$lib/api";
@@ -37,7 +38,7 @@
 				},
 			});
 			dialogOpen = false;
-			goto("/waiter");
+			goto(resolve("/waiter"));
 			toast.message("Created new booking");
 		} catch (err) {
 			toast.error(getError(err).message);
@@ -69,7 +70,7 @@
 
 	{#if query.isSuccess}
 		<div class="mt-4 flex w-full flex-wrap gap-4">
-			{#each query.data as table}
+			{#each query.data as table (table.tableId)}
 				<button class="w-full text-start md:max-w-md" onclick={() => selectTable(table.tableId)}>
 					<Card.Root class="gap-0 p-4">
 						<div class="flex justify-between gap-2">

--- a/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/waiter/+page.svelte
+++ b/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/waiter/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from "$app/paths";
 	import { Card, Button, Badge, Loader } from "@kayord/ui";
 	import Error from "$lib/components/Error.svelte";
 	import { getError } from "$lib/types";
@@ -50,7 +51,7 @@
 
 		<div class="mt-4 flex flex-col flex-wrap items-start gap-2">
 			{#each query.data ?? [] as myTable (myTable.id)}
-				<a href={`/table/menu/${myTable.id}`} class="w-full">
+				<a href={resolve(`/table/menu/${myTable.id}`)} class="w-full">
 					<Card.Root class="w-full gap-1 p-5">
 						<div class="flex justify-between">
 							<h3>{myTable?.table?.name}</h3>

--- a/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/waiter/Item.svelte
+++ b/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/waiter/Item.svelte
@@ -49,7 +49,7 @@
 				<div class="text-muted-foreground mt-2">
 					Options
 					<div class="ml-4">
-						{#each item.orderItemOptions ?? [] as option}
+						{#each item.orderItemOptions ?? [] as option (option.orderItemOptionId)}
 							<div>
 								<span class="text-foreground">{option.option.optionGroup.name}:</span>
 								<span>{option.option.name}</span>
@@ -63,7 +63,7 @@
 				<div class="text-muted-foreground mt-2">
 					Extras
 					<div class="ml-4">
-						{#each item.orderItemExtras ?? [] as extra}
+						{#each item.orderItemExtras ?? [] as extra (extra.orderItemExtraId)}
 							<div>
 								<span class="text-foreground">{extra.extra.extraGroup.name}:</span>
 								<span> {extra.extra.name}</span>

--- a/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/waiter/Orders.svelte
+++ b/client/src/routes/(pages)/(salesPeriod)/(clockedIn)/waiter/Orders.svelte
@@ -19,7 +19,7 @@
 {/if}
 {#if query.data}
 	<div class="flex flex-col gap-2">
-		{#each query.data.tables ?? [] as tableOrder}
+		{#each query.data.tables ?? [] as tableOrder (tableOrder.id)}
 			<Card.Root class="p-4">
 				<div class="flex items-center justify-between">
 					<div class="flex items-center gap-2">
@@ -33,7 +33,7 @@
 					</div>
 				</div>
 				<div class="mt-2 flex flex-col gap-2">
-					{#each tableOrder.orderItems ?? [] as item}
+					{#each tableOrder.orderItems ?? [] as item (item.orderItemId)}
 						<Item {item} refetch={query.refetch} />
 					{/each}
 				</div>

--- a/client/src/routes/(pages)/+page.svelte
+++ b/client/src/routes/(pages)/+page.svelte
@@ -2,18 +2,19 @@
 	import { Button, Loader } from "@kayord/ui";
 	import { status } from "$lib/stores/status.svelte";
 	import { goto } from "$app/navigation";
+	import { resolve } from "$app/paths";
 	import { Header } from "$lib/components/Header";
 
 	let init = $state(false);
 
 	const redirect = async () => {
 		if (status.value.roles.length == 0 || (status.value.roles.length == 1 && status.hasRole("guest"))) {
-			await goto("/guest");
+			await goto(resolve("/guest"));
 		} else if (status.value.roles.length == 1) {
 			if (status.hasRole("front")) {
-				await goto("/waiter");
+				await goto(resolve("/waiter"));
 			} else if (status.hasRole("manager")) {
-				await goto("/manager");
+				await goto(resolve("/manager"));
 			}
 		}
 		init = true;
@@ -38,7 +39,7 @@
 		{/if}
 		{#if status.hasRole("back")}
 			<div class="border-muted flex flex-col gap-2 rounded-md border-1 border-dashed p-2">
-				{#each status.value.divisions as division}
+				{#each status.value.divisions as division (division.id)}
 					<Button href={`/backOffice/${division.id}`} class="w-full" variant="outline">
 						{division.name}
 					</Button>

--- a/client/src/routes/(pages)/colors/+page.svelte
+++ b/client/src/routes/(pages)/colors/+page.svelte
@@ -55,7 +55,7 @@
 </div>
 
 <div class="m-2 flex flex-wrap items-start justify-start gap-2 rounded-md p-2">
-	{#each colors as color}
+	{#each colors as color (color)}
 		<div class="flex items-center gap-2">
 			<div style={"background-color: var(--color-" + color + ");"} class="size-7 rounded-md"></div>
 			<div>{color}</div>
@@ -64,7 +64,7 @@
 </div>
 
 <div class="m-2 flex flex-wrap items-start justify-start gap-2 rounded-md p-2">
-	{#each colors2 as color}
+	{#each colors2 as color (color)}
 		<div class="flex items-center gap-2">
 			<div style={"background-color: var(--" + color + ");"} class="size-7 rounded-md"></div>
 			<div>{color}</div>

--- a/client/src/routes/(pages)/impersonate/+page.svelte
+++ b/client/src/routes/(pages)/impersonate/+page.svelte
@@ -3,6 +3,7 @@
 	import { Card } from "@kayord/ui";
 	import { signInCustomToken } from "$lib/firebase.svelte";
 	import { goto } from "$app/navigation";
+	import { resolve } from "$app/paths";
 
 	const query = createUserUsers(() => ({ pageSize: 100 }));
 
@@ -18,13 +19,13 @@
 		const result = await signInCustomToken(token);
 		console.log("result", result);
 
-		goto("/");
+		goto(resolve("/"));
 	};
 </script>
 
 <div class="m-2">
 	<div class="flex flex-col gap-2">
-		{#each data as user}
+		{#each data as user (user.userId)}
 			<button onclick={() => impersonate(user.userId)}>
 				<Card.Root class="p-2">
 					{user.name}

--- a/client/src/routes/(pages)/manager/admin/+layout@(pages).svelte
+++ b/client/src/routes/(pages)/manager/admin/+layout@(pages).svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { goto } from "$app/navigation";
+	import { resolve } from "$app/paths";
 	import { page } from "$app/state";
 	import { Header } from "$lib/components/Header";
 	import { Button, Sidebar } from "@kayord/ui";
@@ -54,7 +55,7 @@
 		{#if showSidebar}
 			<div class="bg-secondary fixed top-0 bottom-0 left-0 z-0 flex w-14 flex-col justify-between">
 				<div class="flex flex-col gap-4 p-2">
-					<button class="bg-background flex items-center rounded-full p-2" onclick={() => goto("/")}>
+					<button class="bg-background flex items-center rounded-full p-2" onclick={() => goto(resolve("/"))}>
 						<img src="/logo.svg" alt="logo" class="h-6" />
 					</button>
 					{#each menuItems.top as item (item)}

--- a/client/src/routes/(pages)/manager/admin/+page.svelte
+++ b/client/src/routes/(pages)/manager/admin/+page.svelte
@@ -32,7 +32,7 @@
 			</Alert.Root>
 		{:else}
 			<div class="flex flex-col gap-4">
-				{#each query.data ?? [] as printer}
+				{#each query.data ?? [] as printer (printer.id)}
 					<Printer {printer} refetch={query.refetch} canPrint={false} isAdmin={true} />
 				{/each}
 			</div>

--- a/client/src/routes/(pages)/manager/admin/AdminSidebar.svelte
+++ b/client/src/routes/(pages)/manager/admin/AdminSidebar.svelte
@@ -259,7 +259,7 @@
 														<Sidebar.MenuSubButton
 															class="data-[active=true]:bg-primary data-[active=true]:text-primary-foreground cursor-pointer rounded-sm"
 															onclick={() => {
-																goto(subItem.href);
+																goto(resolve(subItem.href as "/"));
 																if (sidebar.isMobile) {
 																	sidebar.setOpenMobile(false);
 																}
@@ -286,7 +286,7 @@
 										hidden: false,
 									}}
 									onclick={() => {
-										goto(item.href);
+										goto(resolve(item.href as "/"));
 										if (sidebar.isMobile) {
 											sidebar.setOpenMobile(false);
 										}

--- a/client/src/routes/(pages)/manager/admin/divisions/Actions.svelte
+++ b/client/src/routes/(pages)/manager/admin/divisions/Actions.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { goto } from "$app/navigation";
+	import { resolve } from "$app/paths";
 	import AddEditDivision from "./AddEditDivision.svelte";
 
 	import { AlertDialog, Button, DropdownMenu } from "@kayord/ui";
@@ -39,7 +40,7 @@
 		</Button>
 	</DropdownMenu.Trigger>
 	<DropdownMenu.Content>
-		<DropdownMenu.Item onclick={() => goto(`/manager/admin/divisions/${division.divisionId}`)}>
+		<DropdownMenu.Item onclick={() => goto(resolve(`/manager/admin/divisions/${division.divisionId}`))}>
 			<TableIcon /> View Roles
 		</DropdownMenu.Item>
 		<DropdownMenu.Item onclick={() => (editOpen = true)}>

--- a/client/src/routes/(pages)/manager/admin/extras/Actions.svelte
+++ b/client/src/routes/(pages)/manager/admin/extras/Actions.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { goto } from "$app/navigation";
+	import { resolve } from "$app/paths";
 	import type { DTOExtraGroupAdminDTO } from "$lib/api";
 	import { AlertDialog, Button, DropdownMenu } from "@kayord/ui";
 	import { toast } from "@kayord/ui/sonner";
@@ -38,7 +39,7 @@
 		</Button>
 	</DropdownMenu.Trigger>
 	<DropdownMenu.Content>
-		<DropdownMenu.Item onclick={() => goto(`/manager/admin/extras/${extraGroup.extraGroupId}`)}>
+		<DropdownMenu.Item onclick={() => goto(resolve(`/manager/admin/extras/${extraGroup.extraGroupId}`))}>
 			<EqualIcon /> Extra Items
 		</DropdownMenu.Item>
 		<DropdownMenu.Item onclick={() => (editOpen = true)}><PencilIcon /> Edit</DropdownMenu.Item>

--- a/client/src/routes/(pages)/manager/admin/halo/+page.svelte
+++ b/client/src/routes/(pages)/manager/admin/halo/+page.svelte
@@ -23,7 +23,7 @@
 			</Alert.Root>
 		{:else}
 			<div class="flex flex-col gap-4">
-				{#each query.data ?? [] as config}
+				{#each query.data ?? [] as config (config.id)}
 					<Config {config} refetch={query.refetch} />
 				{/each}
 			</div>

--- a/client/src/routes/(pages)/manager/admin/menuItems/EditMenuItem.svelte
+++ b/client/src/routes/(pages)/manager/admin/menuItems/EditMenuItem.svelte
@@ -228,7 +228,7 @@
 									{menuValue ? menuValue : "Select Menu"}
 								</Select.Trigger>
 								<Select.Content>
-									{#each menuList as menu}
+									{#each menuList as menu (menu.value)}
 										<Select.Item value={menu.value}>{menu.label}</Select.Item>
 									{/each}
 								</Select.Content>
@@ -251,7 +251,7 @@
 									{sectionValue ? sectionValue : "Select Section"}
 								</Select.Trigger>
 								<Select.Content>
-									{#each sectionList as section}
+									{#each sectionList as section (section.value)}
 										<Select.Item value={section.value}>{section.label}</Select.Item>
 									{/each}
 								</Select.Content>
@@ -274,7 +274,7 @@
 									{divisionValue ? divisionValue : "Select Division"}
 								</Select.Trigger>
 								<Select.Content>
-									{#each divisionList as division}
+									{#each divisionList as division (division.value)}
 										<Select.Item value={division.value}>{division.label}</Select.Item>
 									{/each}
 								</Select.Content>
@@ -297,7 +297,7 @@
 									{billCategoryValue ? billCategoryValue : "Select Bill Category"}
 								</Select.Trigger>
 								<Select.Content>
-									{#each billCatList as cat}
+									{#each billCatList as cat (cat.value)}
 										<Select.Item value={cat.value}>{cat.label}</Select.Item>
 									{/each}
 								</Select.Content>

--- a/client/src/routes/(pages)/manager/admin/menuItems/Extras.svelte
+++ b/client/src/routes/(pages)/manager/admin/menuItems/Extras.svelte
@@ -34,7 +34,7 @@
 			<CirclePlusIcon class="size-4" /> Extra Groups
 		</Button>
 		<div class="mt-2 flex flex-wrap gap-2">
-			{#each extras as current}
+			{#each extras as current (current)}
 				<button
 					onclick={(e) => {
 						removeItem(current);
@@ -56,7 +56,7 @@
 	<Command.List>
 		<Command.Empty>No results found.</Command.Empty>
 		<Command.Group heading="Extras Groups">
-			{#each query.data ?? [] as extraGroup}
+			{#each query.data ?? [] as extraGroup (extraGroup.extraGroupId)}
 				<Command.Item onSelect={() => selectItem(extraGroup.extraGroupId)}>
 					<div class="flex w-full flex-row items-center justify-between">
 						<div class="overflow-hidden text-ellipsis whitespace-nowrap">

--- a/client/src/routes/(pages)/manager/admin/menuItems/Options.svelte
+++ b/client/src/routes/(pages)/manager/admin/menuItems/Options.svelte
@@ -34,7 +34,7 @@
 			<CirclePlusIcon class="size-4" /> Option Groups
 		</Button>
 		<div class="mt-2 flex flex-wrap gap-2">
-			{#each options as current}
+			{#each options as current (current)}
 				<button
 					onclick={(e) => {
 						removeItem(current);
@@ -56,7 +56,7 @@
 	<Command.List>
 		<Command.Empty>No results found.</Command.Empty>
 		<Command.Group heading="Option Groups">
-			{#each query.data ?? [] as optionGroup}
+			{#each query.data ?? [] as optionGroup (optionGroup.optionGroupId)}
 				<Command.Item onSelect={() => selectItem(optionGroup.optionGroupId)}>
 					<div class="flex w-full flex-row items-center justify-between">
 						<div class="overflow-hidden text-ellipsis whitespace-nowrap">

--- a/client/src/routes/(pages)/manager/admin/menus/Actions.svelte
+++ b/client/src/routes/(pages)/manager/admin/menus/Actions.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { goto } from "$app/navigation";
+	import { resolve } from "$app/paths";
 	import type { EntitiesMenu } from "$lib/api";
 	import { AlertDialog, Button, DropdownMenu } from "@kayord/ui";
 	import { toast } from "@kayord/ui/sonner";
@@ -38,7 +39,7 @@
 		</Button>
 	</DropdownMenu.Trigger>
 	<DropdownMenu.Content>
-		<DropdownMenu.Item onclick={() => goto(`/manager/admin/menus/${menu.id}`)}>
+		<DropdownMenu.Item onclick={() => goto(resolve(`/manager/admin/menus/${menu.id}`))}>
 			<EqualIcon /> Sections
 		</DropdownMenu.Item>
 		<DropdownMenu.Item onclick={() => (editOpen = true)}><PencilIcon /> Edit</DropdownMenu.Item>

--- a/client/src/routes/(pages)/manager/admin/options/Actions.svelte
+++ b/client/src/routes/(pages)/manager/admin/options/Actions.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { goto } from "$app/navigation";
+	import { resolve } from "$app/paths";
 	import type { DTOOptionGroupBasicDTO } from "$lib/api";
 	import { AlertDialog, Button, DropdownMenu } from "@kayord/ui";
 	import { toast } from "@kayord/ui/sonner";
@@ -38,7 +39,7 @@
 		</Button>
 	</DropdownMenu.Trigger>
 	<DropdownMenu.Content>
-		<DropdownMenu.Item onclick={() => goto(`/manager/admin/options/${optionGroup.optionGroupId}`)}>
+		<DropdownMenu.Item onclick={() => goto(resolve(`/manager/admin/options/${optionGroup.optionGroupId}`))}>
 			<ListCollapseIcon /> Options
 		</DropdownMenu.Item>
 		<DropdownMenu.Item onclick={() => (editOpen = true)}><PencilIcon /> Edit</DropdownMenu.Item>

--- a/client/src/routes/(pages)/manager/admin/roles/AddEditRole.svelte
+++ b/client/src/routes/(pages)/manager/admin/roles/AddEditRole.svelte
@@ -154,7 +154,7 @@
 									{divTypeValue ? divTypeValue : "Select Role Type"}
 								</Select.Trigger>
 								<Select.Content>
-									{#each divTypeList as divType}
+									{#each divTypeList as divType (divType.value)}
 										<Select.Item value={divType.value}>{divType.label}</Select.Item>
 									{/each}
 								</Select.Content>

--- a/client/src/routes/(pages)/manager/admin/sections/Actions.svelte
+++ b/client/src/routes/(pages)/manager/admin/sections/Actions.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { goto } from "$app/navigation";
+	import { resolve } from "$app/paths";
 	import { AlertDialog, Button, DropdownMenu } from "@kayord/ui";
 	import { toast } from "@kayord/ui/sonner";
 	import { Trash2Icon, PencilIcon, TableIcon, EllipsisVerticalIcon } from "@lucide/svelte";
@@ -38,7 +39,7 @@
 		</Button>
 	</DropdownMenu.Trigger>
 	<DropdownMenu.Content>
-		<DropdownMenu.Item onclick={() => goto(`/manager/admin/sections/${section.id}`)}>
+		<DropdownMenu.Item onclick={() => goto(resolve(`/manager/admin/sections/${section.id}`))}>
 			<TableIcon /> View Tables
 		</DropdownMenu.Item>
 		<DropdownMenu.Item onclick={() => (editOpen = true)}>

--- a/client/src/routes/(pages)/manager/admin/stock/AddStock.svelte
+++ b/client/src/routes/(pages)/manager/admin/stock/AddStock.svelte
@@ -136,7 +136,7 @@
 									{unitSelect}
 								</Select.Trigger>
 								<Select.Content>
-									{#each units ?? [] as result}
+									{#each units ?? [] as result (result.id)}
 										<Select.Item value={result.id.toString()}>
 											{result.name}
 										</Select.Item>
@@ -162,7 +162,7 @@
 									{categorySelect}
 								</Select.Trigger>
 								<Select.Content>
-									{#each category ?? [] as result}
+									{#each category ?? [] as result (result.id)}
 										<Select.Item value={result.id.toString()}>
 											{result.displayName}
 										</Select.Item>

--- a/client/src/routes/(pages)/manager/admin/stock/allocate/Actions.svelte
+++ b/client/src/routes/(pages)/manager/admin/stock/allocate/Actions.svelte
@@ -3,6 +3,7 @@
 	import { ViewIcon } from "@lucide/svelte";
 	import { type DTOStockAllocateDTO } from "$lib/api";
 	import { goto } from "$app/navigation";
+	import { resolve } from "$app/paths";
 
 	interface Props {
 		refetch: () => void;
@@ -17,7 +18,7 @@
 		{
 			icon: ViewIcon,
 			text: "View",
-			action: () => goto(`/manager/admin/stock/allocate/${stockAllocate.id}`),
+			action: () => goto(resolve(`/manager/admin/stock/allocate/${stockAllocate.id}`)),
 		},
 	]}
 />

--- a/client/src/routes/(pages)/manager/admin/stock/allocate/AddAllocation.svelte
+++ b/client/src/routes/(pages)/manager/admin/stock/allocate/AddAllocation.svelte
@@ -194,7 +194,7 @@
 									{fromDivisionSelect}
 								</Select.Trigger>
 								<Select.Content>
-									{#each fromDivisions ?? [] as result}
+									{#each fromDivisions ?? [] as result (result.divisionId)}
 										<Select.Item value={result.divisionId.toString()}>
 											{result.divisionName}
 										</Select.Item>
@@ -220,7 +220,7 @@
 									{toDivisionSelect}
 								</Select.Trigger>
 								<Select.Content>
-									{#each toDivisions ?? [] as result}
+									{#each toDivisions ?? [] as result (result.divisionId)}
 										<Select.Item value={result.divisionId.toString()}>
 											{result.divisionName}
 										</Select.Item>

--- a/client/src/routes/(pages)/manager/admin/stock/orders/Actions.svelte
+++ b/client/src/routes/(pages)/manager/admin/stock/orders/Actions.svelte
@@ -5,6 +5,7 @@
 	import { createStockOrderCancel, type DTOStockOrderResponseDTO } from "$lib/api";
 	import { getError } from "$lib/types";
 	import { goto } from "$app/navigation";
+	import { resolve } from "$app/paths";
 	import { status } from "$lib/stores/status.svelte";
 
 	interface Props {
@@ -40,7 +41,7 @@
 		</Button>
 	</DropdownMenu.Trigger>
 	<DropdownMenu.Content>
-		<DropdownMenu.Item onclick={() => goto(`/manager/admin/stock/orders/${stockOrder.id}`)}>
+		<DropdownMenu.Item onclick={() => goto(resolve(`/manager/admin/stock/orders/${stockOrder.id}`))}>
 			<ViewIcon /> View
 		</DropdownMenu.Item>
 		{#if showCancel}

--- a/client/src/routes/(pages)/manager/admin/stock/orders/AddOrder.svelte
+++ b/client/src/routes/(pages)/manager/admin/stock/orders/AddOrder.svelte
@@ -130,7 +130,7 @@
 									{divisionSelect}
 								</Select.Trigger>
 								<Select.Content>
-									{#each divisions ?? [] as result}
+									{#each divisions ?? [] as result (result.divisionId)}
 										<Select.Item value={result.divisionId.toString()}>{result.divisionName}</Select.Item>
 									{/each}
 								</Select.Content>
@@ -154,7 +154,7 @@
 									{supplierSelect}
 								</Select.Trigger>
 								<Select.Content>
-									{#each suppliers ?? [] as result}
+									{#each suppliers ?? [] as result (result.id)}
 										<Select.Item value={result.id.toString()}>{result.name}</Select.Item>
 									{/each}
 								</Select.Content>

--- a/client/src/routes/(pages)/manager/admin/stockCategory/Actions.svelte
+++ b/client/src/routes/(pages)/manager/admin/stockCategory/Actions.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { goto } from "$app/navigation";
+	import { resolve } from "$app/paths";
 	import { AlertDialog, Button, DropdownMenu } from "@kayord/ui";
 	import { toast } from "@kayord/ui/sonner";
 	import { Trash2Icon, PencilIcon, TableIcon, EllipsisVerticalIcon } from "@lucide/svelte";
@@ -40,7 +41,7 @@
 		</Button>
 	</DropdownMenu.Trigger>
 	<DropdownMenu.Content>
-		<DropdownMenu.Item onclick={() => goto(`/manager/admin/stockCategory/${category.id}`)}>
+		<DropdownMenu.Item onclick={() => goto(resolve(`/manager/admin/stockCategory/${category.id}`))}>
 			<TableIcon /> View Child Categories
 		</DropdownMenu.Item>
 		<DropdownMenu.Item onclick={() => (editOpen = true)}>

--- a/client/src/routes/(pages)/manager/admin/stockCategory/[id]/AddRole.svelte
+++ b/client/src/routes/(pages)/manager/admin/stockCategory/[id]/AddRole.svelte
@@ -69,7 +69,7 @@
 							>
 								<Select.Trigger {...props}>{roleSelect}</Select.Trigger>
 								<Select.Content>
-									{#each rolesQuery.data ?? [] as item}
+									{#each rolesQuery.data ?? [] as item (item.roleId)}
 										<Select.Item value={item.roleId.toString()} label={item.name}>{item.name}</Select.Item>
 									{/each}
 								</Select.Content>

--- a/client/src/routes/(pages)/manager/admin/users/Roles.svelte
+++ b/client/src/routes/(pages)/manager/admin/users/Roles.svelte
@@ -12,7 +12,7 @@
 </script>
 
 <div class="flex gap-2">
-	{#each rolesArray as role}
+	{#each rolesArray as role (role)}
 		<Role {role} {refetch} {userId} />
 	{/each}
 </div>

--- a/client/src/routes/(pages)/manager/cashUp/+page.svelte
+++ b/client/src/routes/(pages)/manager/cashUp/+page.svelte
@@ -8,6 +8,7 @@
 	import CashUpUser from "./CashUpUser.svelte";
 	import { CalendarClockIcon, CheckIcon } from "@lucide/svelte";
 	import { goto } from "$app/navigation";
+	import { resolve } from "$app/paths";
 
 	const query = createCashUpUserGet(() => status.value.outletId);
 
@@ -17,7 +18,7 @@
 		try {
 			await mutation.mutateAsync({ data: { salesPeriodId: status.value.salesPeriodId } });
 			await status.getStatus();
-			await goto("/manager");
+			await goto(resolve("/manager"));
 		} catch (ex) {
 			toast.error(getError(ex).message);
 		}
@@ -58,7 +59,7 @@
 		{/if}
 		<!-- <CashUpSummary /> -->
 		<div class="flex flex-col items-center gap-2">
-			{#each query.data.items as cash}
+			{#each query.data.items as cash (cash.userId)}
 				<CashUpUser {cash} />
 			{/each}
 		</div>

--- a/client/src/routes/(pages)/manager/cashUp/[Id]/[cashUpUserId]/+page.svelte
+++ b/client/src/routes/(pages)/manager/cashUp/[Id]/[cashUpUserId]/+page.svelte
@@ -11,6 +11,7 @@
 	import AddItem from "./AddItem.svelte";
 	import { BookUpIcon } from "@lucide/svelte";
 	import { goto } from "$app/navigation";
+	import { resolve } from "$app/paths";
 	import CashUpItemManual from "./CashUpItemManual.svelte";
 
 	const query = createCashUpUserDetail(
@@ -31,7 +32,7 @@
 			if (response.isError) {
 				toast.error(response.message);
 			} else {
-				await goto("/manager/cashUp");
+				await goto(resolve("/manager/cashUp"));
 			}
 		} catch (error) {
 			toast.error(getError(error).message);
@@ -75,7 +76,7 @@
 			<Card.Content>
 				<div class="mt-5 text-left font-semibold">Cash Up Items</div>
 				<div class="mt-2 flex flex-col items-center gap-2">
-					{#each autoItems as item}
+					{#each autoItems as item (item.id)}
 						<CashUpItem {item} />
 					{/each}
 				</div>
@@ -92,7 +93,7 @@
 							<span>R {query.data.grossBalance.toFixed(2)}</span>
 						</li>
 						<div class="flex flex-col items-center gap-2">
-							{#each manualItems as item}
+							{#each manualItems as item (item.id)}
 								<CashUpItemManual {item} refetch={query.refetch} />
 							{/each}
 						</div>

--- a/client/src/routes/(pages)/manager/salesPeriod/+page.svelte
+++ b/client/src/routes/(pages)/manager/salesPeriod/+page.svelte
@@ -4,6 +4,7 @@
 	import { Button } from "@kayord/ui";
 	import { createSalesPeriodCreate } from "$lib/api";
 	import { goto } from "$app/navigation";
+	import { resolve } from "$app/paths";
 	import { status } from "$lib/stores/status.svelte";
 
 	let name: string = $state("");
@@ -17,7 +18,7 @@
 			});
 			await status.getStatus();
 			toast.success("Successfully opened sales period");
-			await goto("/", { invalidateAll: true });
+			await goto(resolve("/"), { invalidateAll: true });
 		} catch (err) {
 			toast.error("Error opening sales period");
 		}

--- a/client/src/routes/(pages)/switch/SwitchOutlet.svelte
+++ b/client/src/routes/(pages)/switch/SwitchOutlet.svelte
@@ -8,6 +8,7 @@
 	import { createUserAssignOutlet, createOutletGetAllAssigned } from "$lib/api";
 	import { getError } from "$lib/types";
 	import { goto } from "$app/navigation";
+	import { resolve } from "$app/paths";
 	import { status } from "$lib/stores/status.svelte";
 	import { menu } from "$lib/stores/menu.svelte";
 
@@ -32,7 +33,7 @@
 				if (!status.isLoading) {
 					await status.getStatus();
 				}
-				await goto("/", { replaceState: true, invalidateAll: true });
+				await goto(resolve("/"), { replaceState: true, invalidateAll: true });
 			} else {
 				toast.error("Could not set outlet");
 			}
@@ -78,7 +79,7 @@
 								{outletList}
 							</Select.Trigger>
 							<Select.Content>
-								{#each query.data ?? [] as outlet}
+								{#each query.data ?? [] as outlet (outlet.id)}
 									<Select.Item value={outlet.id.toString()}>{outlet.name}</Select.Item>
 								{/each}
 							</Select.Content>


### PR DESCRIPTION
## Summary
Resolves all `svelte/no-navigation-without-resolve` and `svelte/require-each-key` lint errors reported by `pnpm lint`.

### `no-navigation-without-resolve`
- Wrapped every `goto(...)` call and internal `href` (including `<a>` tags and the admin sidebar navigation) in `resolve()` from `$app/paths`, so navigation respects the configured base path.
- For dynamically built URLs (e.g. `` `/table/bill/${id}` ``), `resolve()` is applied to the template literal.
- In `AdminSidebar.svelte` the menu `href` values are typed as plain `string`, so they are narrowed with a cast before `resolve()` (runtime behaviour unchanged).

### `require-each-key`
- Added keys to all `{#each}` blocks using the entity's unique id where one exists, e.g.:
  - `item.orderItemId`, `option.orderItemOptionId`, `extra.orderItemExtraId` (bill/order items)
  - `adjustment.adjustmentId`, `payment.id`, `result.adjustmentTypeId`, `paymentType.paymentTypeId`
  - `option.optionId`, `extra.extraId`, `extraGroup.extraGroupId`, `optionGroup.optionGroupId`
  - `printer.id`, `config.id`, `table.tableId`, `tableOrder.id`, `outlet.id`, `user.userId`, `division.id`, `result.id`, `result.divisionId`, `item.roleId`, `section.menuSectionId`, `cash.userId`, `item.id`
- For primitive lists (colour names, role names, selected ids) the value itself is used as the key.

## Validation
- `pnpm lint`: 0 remaining `no-navigation-without-resolve` / `require-each-key` errors (remaining errors are unused-var rules, unchanged by this PR)
- `pnpm check` (svelte-check): 0 errors, 0 warnings
- `prettier --check`: clean