### PR TITLE
Add print-service SignalR migration implementation guides (Print.md, Print-service.md)

### DIFF
--- a/docs/Print-service.md
+++ b/docs/Print-service.md
@@ -1,0 +1,228 @@
+# Print-service.md — Go print service guide (SignalR client for Kayord POS)
+
+**Audience:** an AI coding agent building the replacement print service in Go.
+
+**Goal:** a small, single-binary Go service that runs on a Raspberry Pi (or any always-on box at a restaurant), connects **outbound** to the POS API's SignalR hub (`/printer-hub`) using an API key created by an outlet manager, receives print jobs, prints them to EPSON-compatible network thermal printers (raw TCP port 9100), performs network scans natively (no nmap), and reports printer reachability.
+
+Companion doc: `docs/Print.md` (server side). Keep the wire contract in sync with it.
+
+---
+
+## 1. Ground rules
+
+- **Outbound connections only.** The device dials the POS API over HTTPS/WSS. No inbound ports, no Redis, no VPN.
+- **Stdlib first.** The only third-party dependency is the SignalR client (`github.com/philippseith/signalr`). No nmap, no ESC/POS library — the POS server pre-renders all ESC/POS byte instructions; the device is a TCP relay.
+- **Config = environment variables.** No config files. Outlet and device identity come from the API key, not from config.
+- Target platforms: `linux/arm` (Pi Zero 1, ARMv6), `linux/arm64` (Pi Zero 2 W, Pi 4/5), `linux/amd64`. Fully static binaries (`CGO_ENABLED=0`).
+
+## 2. Project setup
+
+```bash
+mkdir print-service && cd print-service
+go mod init github.com/kayorddx/print-service
+go get github.com/philippseith/signalr
+```
+
+Layout:
+
+```
+main.go
+internal/config/config.go        — env parsing
+internal/model/model.go          — wire contract types
+internal/hubclient/hubclient.go  — SignalR connection, receiver, reconnect
+internal/printer/printer.go      — TCP print
+internal/scan/scan.go            — native subnet scan (replaces nmap)
+internal/probe/probe.go          — printer reachability probes
+Dockerfile
+Makefile
+README.md
+```
+
+> **Library note:** pin the latest release of `philippseith/signalr` and check its exact option names on pkg.go.dev for that version — the options API has evolved between versions (e.g. `WithHTTPConnectionOptions`, `HTTPConnectionOptions.AccessToken`, `WithConnector`). The snippets below show intent; adapt names to the pinned version.
+
+## 3. Configuration (`internal/config`)
+
+| Env var | Required | Default | Meaning |
+|---|---|---|---|
+| `POS_BASE_URL` | yes | — | e.g. `https://api.kayord.com` (no trailing slash) |
+| `POS_API_KEY` | yes | — | `kpos_{keyId}.{secret}` — created by an outlet manager in the POS admin UI |
+| `LOG_LEVEL` | no | `info` | `debug\|info\|warn\|error` |
+| `PROBE_INTERVAL_SECONDS` | no | `30` | printer reachability probe interval |
+
+Outlet/device identity comes from the key server-side; **the device never configures them**.
+
+## 4. Wire contract (`internal/model`)
+
+SignalR JSON hub protocol uses **camelCase** property names, and .NET serializes `byte[]` as **base64 strings** — Go's `encoding/json` does the same for `[]byte`, so these types line up with the server's `PrintMessage` / `PrinterTarget`:
+
+```go
+package model
+
+// Mirrors Pos.Api Features.Printer.PrintMessage.
+// Action == "nmap" means: run a network scan (legacy value kept for wire compatibility — do NOT rename).
+type PrintMessage struct {
+	Action            string   `json:"action,omitempty"`
+	PrinterName       string   `json:"printerName"`
+	IPAddress         string   `json:"ipAddress"`   // single IP or pattern like "192.168.1.*" for scans
+	Port              int      `json:"port"`
+	PrintInstructions [][]byte `json:"printInstructions"` // raw ESC/POS bytes; empty for scans
+}
+
+// Mirrors Pos.Api PrinterHub.PrinterTarget (sent via SyncPrinters).
+type PrinterTarget struct {
+	PrinterId int    `json:"printerId"`
+	Name      string `json:"name"`
+	IPAddress string `json:"ipAddress"`
+	Port      int    `json:"port"`
+}
+```
+
+## 5. Hub client (`internal/hubclient`)
+
+Connect to `POS_BASE_URL + "/printer-hub"`:
+
+- **Auth:** pass the API key so it reaches the server as `Authorization: Bearer kpos_...` on negotiate + WebSocket upgrade (the server also accepts `access_token` query — header is preferred since we can set headers).
+- **Receiver struct:** methods matching server→client invocations:
+
+```go
+type Receiver struct{ App *App }
+
+// server -> device: print job or scan request
+func (r *Receiver) ReceivePrint(msg model.PrintMessage) { r.App.Dispatch(msg) }
+// server -> device: which printers this device is responsible for probing
+func (r *Receiver) SyncPrinters(targets []model.PrinterTarget) { r.App.SetTargets(targets) }
+```
+
+- **Device → server** (fire-and-forget `client.Send` is fine):
+  - `ReportScanStarted()` — immediately after receiving a scan job
+  - `ReportScanResult(output string)` — text summary when the scan finishes
+  - `ReportPrinterProbe(printerId int, reachable bool, latencyMs int64)`
+- **Reconnect:** use the library's connector-factory option (`WithConnector`) returning a fresh connection, so its built-in exponential-backoff loop handles drops. Log every state change (`ClientConnecting` / `ClientConnected` / closed). The server re-joins this connection to its groups automatically on every (re)connect — there is **no** resubscribe logic to implement.
+- On start, log the key id (the part before `.` — never log the secret).
+
+## 6. Printing (`internal/printer`)
+
+Raw TCP to the printer — the POS server already rendered the ESC/POS bytes:
+
+```go
+func Print(ctx context.Context, msg model.PrintMessage) error {
+	d := net.Dialer{Timeout: 5 * time.Second}
+	conn, err := d.DialContext(ctx, "tcp", net.JoinHostPort(msg.IPAddress, strconv.Itoa(msg.Port)))
+	if err != nil {
+		return fmt.Errorf("dial printer %s:%d: %w", msg.IPAddress, msg.Port, err)
+	}
+	defer conn.Close()
+	_ = conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
+	for _, chunk := range msg.PrintInstructions {
+		if _, err := conn.Write(chunk); err != nil {
+			return fmt.Errorf("write to printer: %w", err)
+		}
+	}
+	return nil
+}
+```
+
+Log success/failure per job. No retries (the POS user can re-print); errors must never crash the process.
+
+## 7. Native scan (`internal/scan`) — replaces nmap
+
+Triggered when `msg.Action == "nmap"` (legacy value — **keep it**, the server may still be migrating). `msg.IPAddress` is either a single IP or a `192.168.1.*`-style pattern; `msg.Port` is the port to test (9100).
+
+- Expand the pattern to a candidate IP list (pattern → `/24` or enumerate octet values; also accept CIDR for robustness).
+- Concurrent TCP-connect check: `net.Dialer{Timeout: 300 * time.Millisecond}`, ~128 concurrent dials via a semaphore, cancelable via context.
+- Flow: invoke `ReportScanStarted` → run scan → build a plain-text summary (host list with `ip:port open`, plus timing — keep it human-readable, the admin UI displays it verbatim) → invoke `ReportScanResult(output)`.
+- This replaces the old nmap flow: no root required, no external binary.
+
+## 8. Reachability probes (`internal/probe`)
+
+- Maintains the target list from `SyncPrinters` (thread-safe swap).
+- Every `PROBE_INTERVAL_SECONDS`, probe each target on a staggered schedule (spread printers across the interval; ~500ms dial timeout).
+- Report each result via `ReportPrinterProbe(printerId, reachable, latencyMs)`.
+- Skip probes while the hub is disconnected; drop stale targets the server no longer sends.
+
+## 9. `main.go` wiring
+
+- Parse config; build `App` (holds hub client handle, target store, worker pool of 1 for print jobs + goroutine per scan/probe).
+- Start the SignalR client; dispatch `ReceivePrint` jobs: `Action == "nmap"` → scan, else → print.
+- Handle `SIGINT`/`SIGTERM`: stop client gracefully, exit 0.
+
+## 10. Build & deploy
+
+**Makefile:**
+
+```makefile
+build-all:
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm   GOARM=6 go build -o dist/print-service-linux-armv6 .
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64        go build -o dist/print-service-linux-arm64 .
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64        go build -o dist/print-service-linux-amd64 .
+```
+
+**Dockerfile** (multi-arch, no base needed — static binary):
+
+```dockerfile
+FROM --platform=$BUILDPLATFORM golang:1.24 AS build
+ARG TARGETOS TARGETARCH
+WORKDIR /src
+COPY . .
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /print-service .
+
+FROM scratch
+COPY --from=build /print-service /print-service
+ENTRYPOINT ["/print-service"]
+```
+
+```bash
+docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v6 \
+  -t ghcr.io/kayorddx/print-service:latest --push .
+```
+
+**systemd** (for Pis without Docker):
+
+```ini
+# /etc/systemd/system/print-service.service
+[Unit]
+Description=Kayord print service
+After=network-online.target
+
+[Service]
+Environment=POS_BASE_URL=https://api.kayord.com
+EnvironmentFile=-/etc/kayord/print-service.env   # POS_API_KEY lives here, chmod 600
+ExecStart=/usr/local/bin/print-service
+Restart=always
+RestartSec=5
+User=kayord
+
+[Install]
+WantedBy=multi-user.target
+```
+
+## 11. Local testing checklist
+
+1. POS API running locally (`dotnet run --project Pos.Api` in the pos repo) + Postgres/Redis via `docker compose up -d`.
+2. Create a key as a manager (admin UI or Swagger `POST /printerservicekey`).
+3. Fake printer: `nc -lk 9100` in another terminal (or a 5-line Go TCP echo) — verify `ReceivePrint` bytes arrive; better, test against a real EPSON on the LAN.
+4. Start the service: `POS_BASE_URL=http://localhost:5117 POS_API_KEY=kpos_... go run .`
+5. Verify:
+   - [ ] Server logs show the hub connection + `SyncPrinters` payload
+   - [ ] POS admin printers page shows the device online **live** (badge flips without refresh)
+   - [ ] `POST /printer/test` prints on the fake/real printer
+   - [ ] `POST /printer/scan` → `ReportScanStarted`/`ReportScanResult` appear in the scan results UI (no nmap installed — proves the native scan path)
+   - [ ] Probes reported; a printer with the cable pulled flips `PrinterReachable` to false within one interval
+   - [ ] Kill the network for 30s → service reconnects by itself and prints still work
+   - [ ] Revoked key (revoke in UI) → connection dropped and cannot re-establish
+
+## 12. Acceptance criteria
+
+- [ ] Static binaries build for `linux/armv6`, `linux/arm64`, `linux/amd64`; Docker image builds multi-arch from `scratch`
+- [ ] Connects to `/printer-hub` with only `POS_BASE_URL` + `POS_API_KEY`; rejects nothing server-side without a valid key
+- [ ] Prints raw instructions to TCP printers; scan requests answered natively (no nmap binary anywhere)
+- [ ] `ReportPrinterProbe` flow works; probes auto-recover after reconnect
+- [ ] Survives: network loss, API restart, invalid-key-at-startup (retries with backoff, logs clearly)
+- [ ] No secrets in logs (key id only); no inbound listeners; single small binary
+
+## 13. Out of scope (do not build now)
+
+- ESC/POS `DLE EOT` status polling (paper-out etc.) — stretch goal, same socket
+- USB/serial printer support (OS-specific device handling)
+- Local job queue/persistence — print is fire-and-forget by design
+- mTLS / cert pinning (revisit after launch if required)

--- a/docs/Print.md
+++ b/docs/Print.md
@@ -1,0 +1,246 @@
+# Print.md — Pos.Api + Client guide for print-over-SignalR
+
+**Audience:** an AI coding agent working in this repo (`kayordDX/pos`). Follow the phases in order. Check off each verification step before moving on.
+
+**Goal:** replace the Redis pub/sub print transport with SignalR, add outlet-manager-managed API keys that a (new, Go) print service uses to authenticate, and expose richer printer states in the admin UI. **The existing Redis path stays in place and functional until every printer box is migrated** (dual-transport via a config flag).
+
+Background: `docs/print-service-signalr-migration.md` (architecture rationale). The device-side guide is `docs/Print-service.md` — keep the wire contract in sync with it.
+
+---
+
+## 0. Ground rules
+
+- Do **not** modify `Pos.Api/Hubs/KayordHub.cs` auth (Firebase JWT) — device keys must never be able to reach user features.
+- Do **not** remove any Redis code in this repo. Pos.Api still uses Redis for the SignalR backplane, auth OTP, and scan results during migration. Cleanup happens only in Phase 7.
+- New API surface must be discoverable by Swagger (FastEndpoints auto-discovery handles this) so the client can regenerate its API layer.
+- Default config must keep current behavior (`Print:Transport=redis`). Ops flips it per environment; no behavior change on merge.
+
+## 1. Current state (read these first)
+
+| Concern | File |
+|---|---|
+| Print send (Redis publish to `print:{outletId}:{deviceId}`) | `Pos.Api/Services/PrintService.cs` |
+| User hub (Firebase JWT, `/hub`, Redis backplane) | `Pos.Api/Hubs/KayordHub.cs`, `Pos.Api/Hubs/UserProvider.cs`, `Pos.Api/Program.cs` |
+| Auth registration (JWT bearer + `access_token` query for hubs) | `Pos.Api/Common/Extensions/AuthExtensions.cs` |
+| Scan trigger (sends `PrintMessage` with `Action="nmap"`) | `Pos.Api/Features/Printer/Scan/Endpoint.cs` |
+| Scan results (reads Redis keys `status-print:*` / `result-print:*`) | `Pos.Api/Features/Printer/ScanResults/Endpoint.cs` |
+| Printer list + `IsConnected` via `PUBSUB NUMSUB` hack | `Pos.Api/Features/Printer/List/Endpoint.cs` |
+| Printer entity (`OutletId`, `DeviceId`, `IPAddress`, `Port`) | `Pos.Api/Entities/Printer.cs` |
+| Manager policy pattern | `Pos.Api/Features/MenuItem/Create/Endpoint.cs` (`Policies(Constants.Policy.Manager)`), `Pos.Api/Features/Auth/RoleTypeHandler.cs` |
+| EF DbContext / entity config | `Pos.Api/Data/AppDbContext.cs`, `Pos.Api/Data/Configuration/` |
+| Admin printers page | `client/src/routes/(pages)/manager/admin/+page.svelte`, dialogs in `client/src/routes/(pages)/manager/admin/printers/` |
+| Hub store (frontend SignalR client) | `client/src/lib/stores/hub.svelte.ts` |
+| API client regen | `client/package.json` script `api` (curl openapi → `orval`) |
+
+```
+today:  Pos.Api --publish--> Redis "print:{outletId}:{deviceId}" <---- .NET print-service (Pi)
+        Pos.Api <--keys-- Redis "status-print:*" / "result-print:*" -- nmap scan results
+        Pos.Api     PUBSUB NUMSUB  -> IsConnected guess
+```
+
+## 2. Target
+
+```
+Pos.Api (public HTTPS)
+ ├─ /hub          KayordHub   — Firebase users (UNCHANGED)
+ └─ /printer-hub  PrinterHub  — API-key auth (scheme "PrinterKey")
+        ▲ outbound WSS only
+        │
+   Go print-service (Pi Zero) — see docs/Print-service.md
+```
+
+- Print jobs: server → `Clients.Group("printer-outlet-{outletId}-device-{deviceId}").ReceivePrint(msg)`
+- Scan results: device → hub (`ReportScanStarted` / `ReportScanResult`) → `IMemoryCache` (replaces Redis keys)
+- Printer reachability: device probes each printer (TCP dial) → `ReportPrinterProbe` → `PrinterProbeCache`
+- Device online: hub `OnConnectedAsync`/`OnDisconnectedAsync` → `PrinterConnectionTracker` (replaces `PUBSUB NUMSUB`)
+
+---
+
+## 3. Phase 1 — `PrintServiceKey` entity + EF migration
+
+Create `Pos.Api/Entities/PrintServiceKey.cs`:
+
+```csharp
+namespace Pos.Api.Entities;
+
+public class PrintServiceKey : AuditableEntity
+{
+    public int Id { get; set; }
+    public int OutletId { get; set; }
+    public int DeviceId { get; set; } = 1;      // bound at creation; replaces per-Pi Config:DeviceId
+    public string KeyId { get; set; } = string.Empty;   // public id, e.g. "pk_8f3a91c2"; unique, indexed
+    public string SecretHash { get; set; } = string.Empty; // SHA-256 of secret (hex); secret itself never stored
+    public string Name { get; set; } = string.Empty;       // human label, e.g. "Front-desk Pi"
+    public DateTime? RevokedAt { get; set; }
+    public DateTime? LastSeenAt { get; set; }
+}
+```
+
+- Register `DbSet<PrintServiceKey>` in `Pos.Api/Data/AppDbContext.cs` and add an EF configuration in `Pos.Api/Data/Configuration/` (unique index on `KeyId`; follow `PrinterConfiguration.cs` pattern).
+- Migration (run from repo root — note: README paths `src/Pos.Api` are stale):
+
+```bash
+dotnet ef migrations add AddPrintServiceKey --context AppDbContext --project Pos.Api --startup-project Pos.Api --output-dir Data/Migrations
+dotnet ef database update --context AppDbContext --project Pos.Api --startup-project Pos.Api
+```
+
+**Verify:** migration applies cleanly against the dev DB (`docker compose up -d` first).
+
+## 4. Phase 2 — Key management endpoints (outlet managers)
+
+New feature folder `Pos.Api/Features/PrintServiceKey/` following the existing FastEndpoints layout (`Create/`, `List/`, `Revoke/`, each with `Endpoint.cs` + `Request.cs` + `Validator`). All three endpoints call `Policies(Constants.Policy.Manager);` in `Configure()`.
+
+**Key format:** `kpos_{keyId}.{secret}`
+- `keyId`: `"pk_"` + 8 hex chars (URL-safe, shown in lists)
+- `secret`: 32 random bytes (`RandomNumberGenerator.GetBytes(32)`), base64url-encoded
+- Store **only** `Convert.ToHexString(SHA256.HashData(secretBytes))` in `SecretHash`. The full key is returned **once** in the Create response and never again.
+
+**Create** — `POST /printerservicekey`
+- Request: `{ outletId, deviceId, name }` (validate against `Constants.Policy.Manager` role; also scope to the caller's outlet like `Printer/List` does via `r.OutletId` pattern — check how other endpoints obtain the current outlet and mirror it)
+- Generates the key, saves the entity, responds with DTO including `fullKey` (plaintext, this response only)
+
+**List** — `GET /printerservicekey` (by current outlet)
+- Returns: `id, keyId, name, deviceId, maskedKey ("kpos_pk_8f3a…"), lastSeenAt, revokedAt, created`
+- Follow the existing DTO + `ProjectToDto()` mapping pattern used by `PrinterDTO`.
+
+**Revoke** — `POST /printerservicekey/revoke`
+- Request: `{ id }`. Sets `RevokedAt = DateTime.UtcNow`. Must also evict the auth cache entry for that KeyId (Phase 3) so revocation is immediate.
+
+**Verify:** endpoints appear in Swagger; a manager token can create/list/revoke; a non-manager gets 403.
+
+## 5. Phase 3 — `PrinterKey` authentication handler
+
+New file `Pos.Api/Features/Auth/PrinterKeyAuthenticationHandler.cs`:
+
+- `AuthenticationHandler<AuthenticationSchemeOptions>`, scheme name constant `Constants.Policy.PrinterKeyScheme` (add constant, value `"PrinterKey"`).
+- Token extraction, in order: `Authorization: Bearer <key>` header, then `Request.Query["access_token"]` (SignalR passes the query string through to the WebSocket; browsers can't set WS headers).
+- Reject anything not starting with `"kpos_"` (return `AuthenticateResult.NoResult()` so other schemes are unaffected elsewhere).
+- Split on `.` → `keyId` + `secret`. Look up `KeyId` in `DbContext.PrinterServiceKey`. Compare `SHA256(secret)` with stored hash using `CryptographicOperations.FixedTimeEquals`. Fail if `RevokedAt != null`.
+- **Cache:** `IMemoryCache` entry `printerkey:{keyId}` → validated claims, 5-minute sliding expiry. On Revoke (Phase 2), `_memoryCache.Remove(...)`.
+- Success → `ClaimsPrincipal` with a `ClaimsIdentity` containing claims: `outlet_id`, `device_id`, `key_id`. `DefaultAuthenticateScheme`/`DefaultChallengeScheme` wiring: register via `services.AddAuthentication("PrinterKey")...` **additively** — do NOT replace the existing Firebase JWT default. The Firebase scheme stays the default; this scheme is only selected explicitly (Phase 4).
+- On successful authentication, update `LastSeenAt` on the key entity (fire-and-forget, throttle to once per minute per key).
+
+Register the handler and `IMemoryCache` in `AuthExtensions.ConfigureAuth`.
+
+**Verify:** unit-style check with curl — `curl -H "Authorization: Bearer kpos_..." /printerservicekey-test` style probe or temporary endpoint; revoked key fails immediately.
+
+## 6. Phase 4 — `PrinterHub`
+
+New files `Pos.Api/Hubs/PrinterHub.cs` (+ `IPrinterHub` client interface) and `Pos.Api/Hubs/PrinterConnectionTracker.cs`.
+
+```csharp
+public interface IPrinterHub                      // server -> device
+{
+    Task ReceivePrint(Features.Printer.PrintMessage message);
+    Task SyncPrinters(List<PrinterTarget> printers);
+}
+
+public interface IPrinterHubServer                // device -> server (validate everything against claims!)
+{
+    Task ReportScanStarted();
+    Task ReportScanResult(string output);
+    Task ReportPrinterProbe(int printerId, bool reachable, long latencyMs);
+}
+```
+
+`PrinterTarget` (wire contract — must match `docs/Print-service.md`):
+
+```csharp
+public class PrinterTarget { public int PrinterId; public string Name; public string IPAddress; public int Port; }
+```
+
+Hub behavior:
+- `OnConnectedAsync`: read `outlet_id`, `device_id`, `key_id` claims → join groups `printer-outlet-{outletId}` and `printer-outlet-{outletId}-device-{deviceId}` (**server-side only — never accept a client-called JoinGroup**). Increment `PrinterConnectionTracker`, broadcast device-online to `KayordHub` group `outlet-{outletId}` (existing outlet group naming — check `RefreshOutlet` usage for the convention), and send `SyncPrinters(...)` with the device's printers from the DB.
+- `OnDisconnectedAsync`: decrement tracker, broadcast device-offline.
+- `ReportScanStarted` / `ReportScanResult`: derive outlet/device **from claims** (never trust parameters), write `IMemoryCache` keys `scan-status:{outletId}:{deviceId}` and `scan-result:{outletId}:{deviceId}` with 5-minute expiry (mirrors old Redis TTL).
+- `ReportPrinterProbe`: verify `printerId` belongs to the calling device's outlet+deviceId (cache the `SyncPrinters` set per device to avoid DB hits), then store in `PrinterProbeCache` (singleton, `printerId` → result + timestamp) and broadcast `PrinterStatusChanged(outletId, printerId, reachable)` on `KayordHub` so the admin UI updates live.
+
+New singletons (DI in a new `Common/Extensions/PrinterHubExtensions.cs` or inside `ConfigurePrint`):
+- `PrinterConnectionTracker` — `ConcurrentDictionary<(int outletId, int deviceId), int>`; methods `Connected/Disconnected/OnlineDevices(outletId)/IsOnline(outletId, deviceId)`.
+- `PrinterProbeCache` — `ConcurrentDictionary<int, (bool reachable, long latencyMs, DateTime updatedAt)>`; treat entries older than 10 minutes as unknown (mirrors old `PrinterStatus.IsOutdated`).
+
+`Program.cs`:
+
+```csharp
+app.MapHub<PrinterHub>("/printer-hub")
+   .RequireAuthorization(new AuthorizeAttribute { AuthenticationSchemes = "PrinterKey" });
+```
+
+**Verify:** with any WS client, connect with a valid key → connection sticks; connect with a garbage/revoked key → 401.
+
+## 7. Phase 5 — Send-side switch (dual transport, flag-guarded)
+
+**`Pos.Api/Services/PrintService.cs`** — inject `IHubContext<PrinterHub, IPrinterHub>` + `IConfiguration`. Keep the existing Redis publish exactly as-is:
+
+```csharp
+public async Task Print(int outletId, int deviceId, PrintMessage msg)
+{
+    var transport = _config.GetValue<string>("Print:Transport") ?? "redis"; // redis | both | signalr
+    if (transport is "redis" or "both")
+    {
+        /* existing Redis publish — unchanged */
+    }
+    if (transport is "signalr" or "both")
+    {
+        await _hub.Clients.Group($"printer-outlet-{outletId}-device-{deviceId}").ReceivePrint(msg);
+    }
+}
+```
+
+**`Pos.Api/Features/Printer/ScanResults/Endpoint.cs`** — read `IMemoryCache` scan entries first; **fall back** to the old Redis keys while legacy devices are still in play. Delete the Redis fallback only in Phase 7.
+
+**`Pos.Api/Features/Printer/List/Endpoint.cs`** — extend the DTO (`PrinterDTO` + mapping) with:
+- `DeviceOnline: bool` ← `PrinterConnectionTracker.IsOnline(outletId, deviceId)`
+- `PrinterReachable: bool?` ← `PrinterProbeCache` (null = never probed / stale)
+- Keep the existing `IsConnected` field populated as today (Redis `PUBSUB` path) until Phase 7; new UI should prefer `DeviceOnline`/`PrinterReachable`.
+
+**Config:** add `Print:Transport` to `appsettings.json` with value `"redis"` (default, zero behavior change). Document `Print__Transport` env override for deployments.
+
+**Verify:** `dotnet build` warning-free; with flag `redis`, existing print flow works exactly as before (regression test: `/bill/print`, `/printer/test`, `/printer/scan`).
+
+## 8. Phase 6 — Client (Svelte)
+
+1. **Regenerate API client:** run the API locally (`dotnet run --project Pos.Api`, port 5117), then in `client/`: `pnpm run api`. Confirm new `printerservicekey` tag functions appear in `client/src/lib/api/generated/`.
+2. **API keys UI** (follow the dialog patterns in `AddPrinter.svelte` / `DeletePrinter.svelte`, `@kayord/ui` components, `sonner` toasts):
+   - `client/src/routes/(pages)/manager/admin/printers/PrintKeys.svelte` — key list: masked key, name, device, last-seen, revoked badge, revoke button (confirm dialog).
+   - `client/src/routes/(pages)/manager/admin/printers/AddPrintKey.svelte` — create dialog: outlet (default current), deviceId (number, default 1), name. On success show the **full key once** with copy-to-clipboard and a "you will not see this again" warning.
+   - Mount both on the admin printers page (`admin/+page.svelte`), e.g. a "Print devices / keys" section; if a separate route is preferred, also add an entry to `AdminSidebar.svelte` following its existing pattern.
+3. **Printer card states** (`client/src/lib/components/Printer.svelte`): show two distinct badges — `DeviceOnline` (box reachable via hub) and `PrinterReachable` (printer answers on its port; `unknown` when null). Keep `isConnected` rendering for legacy fallback.
+4. **Live updates:** in the printers page, subscribe via `hub.svelte.ts`: `hub.on("PrinterStatusChanged", ...)` (payload `{ outletId, printerId, reachable, online }`) and update the list state without refetch; also handle device online/offline broadcast. Unsubscribe on destroy.
+5. Type the payloads locally (hand-written types are fine for hub events; orval only covers REST).
+
+**Verify:** create key in UI → full key shown once → appears masked in list; revoking removes it; badges render; a real (or fake, see Print-service.md) device flips badges live without refresh.
+
+## 9. Phase 7 — Cutover & cleanup (only after ALL printer boxes run the Go service)
+
+Sequence (ops + code):
+1. Deploy release with `Print:Transport=redis` (safe, nothing uses hub yet).
+2. Per box: create key in admin UI → stop old .NET service → start Go print-service with that key (see `docs/Print-service.md`). **One device per outlet+deviceId pair** — never run old and new service for the same pair simultaneously (double prints under `both`).
+3. When the last box is migrated: set `Print__Transport=both`, verify prints + scans on every box, then set `Print__Transport=signalr`.
+4. Final cleanup PR (only after `signalr` is stable everywhere):
+   - Delete Redis publish from `PrintService.cs`, the `PUBSUB NUMSUB` block and `IsConnected` fallback in `Printer/List`, Redis fallback in `ScanResults`.
+   - Delete old scan UI remnants if any; drop Redis `status-*`/`result-*` conventions from docs.
+   - Keep: Redis **backplane** (`AddStackExchangeRedis`), `RedisClient` (OTP/auth caching), `compose.yml` Redis.
+
+Rollback at any point before step 4: flip `Print__Transport` back to `redis`.
+
+---
+
+## 10. Acceptance criteria
+
+- [ ] Migration `AddPrintServiceKey` applies and reverts cleanly
+- [ ] Manager can create/list/revoke keys via UI; full key shown exactly once; non-managers get 403
+- [ ] Revoked key rejected immediately on new hub connections
+- [ ] `/printer-hub` requires `PrinterKey` scheme; `/hub` auth unchanged (Firebase still works)
+- [ ] With `Print:Transport=redis`: zero behavior change (print, test, scan all work via Redis)
+- [ ] With `Print:Transport=both` or `signalr` + a connected Go device: prints, scans (native, `Action="nmap"` kept for wire compat), and probes work end-to-end
+- [ ] Scan results readable via `ScanResults` endpoint (memory cache, Redis fallback during migration)
+- [ ] Printer list shows `DeviceOnline` + `PrinterReachable`; badges update live via `PrinterStatusChanged`
+- [ ] `dotnet build` / `svelte-check` clean; client regenerated from Swagger
+
+## 11. Out of scope (do not build now)
+
+- ESC/POS `DLE EOT` paper/error status (stretch goal, device-side)
+- Key rotation endpoint (revoke + create is sufficient)
+- TickerQ job for pruning stale keys
+- Deleting the legacy .NET print-service repo

--- a/docs/print-service-signalr-migration.md
+++ b/docs/print-service-signalr-migration.md
@@ -1,0 +1,171 @@
+# Print Service: Redis Pub/Sub → SignalR Migration Plan
+
+> **Superseded as an implementation guide** by `docs/Print.md` (server side) and `docs/Print-service.md` (Go client). This document is kept as architecture background and rationale.
+
+## Current state
+
+```
+Pos.Api ──publish──> Redis channel "print:{outletId}:{deviceId}" <──subscribe── print-service (Pi Zero, on LAN)
+                        │
+                        └── keys "status-print:…"/"result-print:…" (nmap scan results)
+                        └── PUBSUB CHANNELS/NUMSUB (device online status)
+```
+
+| Concern | Today | Where |
+|---|---|---|
+| Send print job | `PrintService.Print()` publishes JSON to Redis | `Pos.Api/Services/PrintService.cs` |
+| Receive print job | `Subscriber : BackgroundService` subscribes per configured outlet + static `Config:DeviceId` | `print-service/Services/Subscriber.cs` |
+| Print | ESCPOS_NET → network printer (unchanged) | `print-service/Utils/Printer.cs` |
+| nmap scan | `Action == "nmap"` → runs nmap, writes `result-*`/`status-*` Redis keys with 5-min TTL | `print-service/Utils/Nmap.cs` |
+| Read scan results | API reads those Redis keys | `Pos.Api/Features/Printer/ScanResults/Endpoint.cs` |
+| Device online? | `PUBSUB NUMSUB` count > 0 | `Pos.Api/Features/Printer/List/Endpoint.cs` |
+| Hub (users) | `KayordHub` at `/hub`, Firebase JWT auth, Redis backplane | `Pos.Api/Hubs/KayordHub.cs` |
+
+**Pain points:** print-service needs network access to Redis (can't work off-site / behind NAT unless Redis is exposed — bad), static outlet/device config per Pi, no real auth, fragile online detection via pub/sub introspection.
+
+## Target architecture
+
+```
+Pos.Api (public HTTPS)
+ ├── /hub            KayordHub    — Firebase users (unchanged, Redis backplane kept for scale-out)
+ └── /printer-hub    PrinterHub   — API-key auth, device identity from key claims
+                          ▲
+                          │  outbound WSS only (works behind NAT / off-site)
+ print-service (Pi Zero) ─┘
+   config shrinks to: Pos:BaseUrl + Pos:ApiKey
+```
+
+- Print jobs: server → `Clients.Group(...)` → `ReceivePrint(PrintMessage)`
+- Scan results: device → server (`ReportScanStarted` / `ReportScanResult`) → stored in `IMemoryCache` (mirrors today's 5-min Redis TTL) and/or pushed to the outlet's `KayordHub` group
+- Online status: `OnConnectedAsync`/`OnDisconnectedAsync` — the server *knows* which device connections exist; no more `PUBSUB NUMSUB`
+- Redis **backplane** for SignalR scale-out stays; the print pub/sub usage of Redis goes away (Pos.Api still uses Redis for OTP/auth caching — that stays)
+
+## 1. API keys (outlet manager creates, print-service authenticates)
+
+New entity `PrintServiceKey` (EF migration in `Pos.Api/Data/Migrations`):
+
+```csharp
+public class PrintServiceKey : AuditableEntity
+{
+    public int Id { get; set; }
+    public int OutletId { get; set; }
+    public int DeviceId { get; set; } = 1;          // bound at creation; replaces Config:DeviceId
+    public string KeyId { get; set; }               // public id, e.g. "pk_8f3a…" (plaintext, indexed, unique)
+    public string SecretHash { get; set; }          // SHA-256 of secret — sufficient for high-entropy random secrets
+    public string Name { get; set; }                // "Front-desk Pi", "Bar printer box"
+    public DateTime? RevokedAt { get; set; }
+    public DateTime? LastSeenAt { get; set; }
+}
+```
+
+- **Format:** `kpos_{keyId}.{secret}` — keyId visible for management, secret random 32 bytes base64url. **Shown once** at creation.
+- **Endpoints** (new `Pos.Api/Features/PrintServiceKey/`): `Create`, `List` (masked `kpos_pk_8f3a…`, shows LastSeenAt/RevokedAt), `Revoke`. Authorized to outlet managers via the existing role checks pattern (`User/AssignOutlet`, `RoleHelper` style — same outlet scoping as `Printer/List`).
+- **Hub auth:** new `PrinterKeyAuthenticationHandler` (`AuthenticationScheme: "PrinterKey"`). Token comes from `access_token` query param or `Authorization: Bearer` (SignalR JS/.NET clients support both). Handler: parse prefix → hash secret → lookup `KeyId` → check `RevokedAt == null` → build `ClaimsPrincipal` with claims `outlet_id`, `device_id`, `key_id`. Cache key→claims in `IMemoryCache` ~5 min (revoke clears the cache entry; worst case a revoked key lives ≤5 min).
+- `Pos:BaseUrl` must be the public HTTPS URL; Firebase JWT path on `/hub` is untouched.
+
+## 2. Server: `PrinterHub`
+
+New `Pos.Api/Hubs/PrinterHub.cs` (+ `IPrinterHub` client interface), mapped with `.RequireAuthorization(policy → schemes: "PrinterKey")`:
+
+```csharp
+public interface IPrinterHub
+{
+    Task ReceivePrint(PrintMessage message);     // replaces Redis pub/sub delivery
+}
+
+public interface IPrinterHubServer   // client → server
+{
+    Task ReportScanStarted();                    // replaces "status-print:*" key
+    Task ReportScanResult(string output);        // replaces "result-print:*" key
+}
+```
+
+- **Groups joined server-side** in `OnConnectedAsync` from claims (never client-called `JoinGroup` — prevents privilege escalation): `printer-outlet-{outletId}` and `printer-outlet-{outletId}-device-{deviceId}`. Groups are per-connection, so reconnects re-join automatically.
+- `OnConnectedAsync` / `OnDisconnectedAsync`: bump `LastSeenAt` on the key, broadcast device online/offline to the outlet's `KayordHub` group (live status in admin UI).
+- `ReportScanStarted` → set `IMemoryCache["scan-status:{outletId}:{deviceId}"]` (5-min expiry); `ReportScanResult` → set `IMemoryCache["scan-result:{outletId}:{deviceId}"]`.
+- **Connection registry:** a singleton `PrinterConnectionTracker` (thread-safe dict deviceId → count of open connections per outlet) replaces the `PUBSUB NUMSUB` logic in `Printer/List` — `IsConnected` becomes a simple lookup.
+
+### Per-printer reachability probes (new capability)
+
+Today `IsConnected` only proves the print-service *device* is subscribed — a physically unplugged printer still shows green. The device's TCP-dial capability enables true per-printer status:
+
+1. Server → device on connect: `SyncPrinters([{ printerId, ip, port }, ...])` from the DB, scoped by the key's claims.
+2. Device probes each target on a staggered interval (30–60s): one `net.DialTimeout(ip, port, 500ms)` per printer; reports `ReportPrinterProbe(printerId, reachable, latencyMs)`.
+3. Server stores results in a `PrinterProbeCache` (printerId → result + timestamp; treat >10 min as outdated, matching old `PrinterStatus.IsOutdated`) and broadcasts `PrinterStatusChanged(outletId, printerId, reachable)` on `KayordHub`.
+4. `Printer/List` exposes `DeviceOnline` (tracker) + `PrinterReachable` (probe cache); the Svelte printers page subscribes via the existing `hub.svelte.ts` store for live badge updates.
+5. On-demand probe ("check" button) invokes an immediate dial instead of waiting for the interval — replaces the nmap round trip.
+
+Stretch: ESC/POS real-time status (`DLE EOT`) over the same raw socket for paper-out/error states — pure Go, no library. Not required for parity.
+
+## 3. Server: replace send-side
+
+- `Pos.Api/Services/PrintService.cs`: inject `IHubContext<PrinterHub, IPrinterHub>`; `Print()` becomes `Clients.Group($"printer-outlet-{outletId}-device-{deviceId}").ReceivePrint(msg)`.
+- **Dual-publish transition:** config flag `Print:Transport: redis | both | signalr` — publish to Redis *and* SignalR while Pis are being rolled out.
+- `Printer/ScanResults/Endpoint.cs`: read from `IMemoryCache` instead of Redis keys (same DTO, same 5-min semantics).
+- `Printer/List/Endpoint.cs`: delete the `PUBSUB` block, use `PrinterConnectionTracker`.
+- Keep `PrintMessage` DTO shape; duplicate it in print-service (as today) or later extract a tiny shared contracts project.
+
+## 4. Print-service changes
+
+- Add `Microsoft.AspNetCore.SignalR.Client`; drop `StackExchange.Redis` (+ `RedisClient`, `RedisExtensions`, `Worker`).
+- `Config` becomes: `BaseUrl` + `ApiKey`. `OutletIds`/`DeviceId` disappear — identity comes from the key.
+- New `PosConnection : BackgroundService` replaces `Subscriber`:
+  - `HubConnectionBuilder.WithAutomaticReconnect()` + outer restart loop for initial-connect failures (Pi Zero networks are flaky; today's `_failureCount` watchdog becomes unnecessary — SignalR handles keep-alive/reconnect).
+  - Register `ReceivePrint` handler → same dispatch as today (`Action == "nmap"` → `NMap.Scan`, else `Printer.Print`).
+  - `NMap.Scan` reports via `connection.InvokeAsync("ReportScanStarted")` / `"ReportScanResult"` instead of writing Redis keys; accepts the outlet/device ids from claims-free local context (or echo them in the hub call).
+  - On `Closed`/`Reconnected` events: log + update state; server re-adds groups on every (re)connect, so no resubscribe logic needed.
+- `Program.cs`: swap hosted services, remove `ConfigureRedis`.
+- README/secrets: `dotnet user-secrets set "Pos:ApiKey" "kpos_…"`; compose sample drops the Redis connection string.
+
+## 5. Client (Svelte) changes
+
+- Admin → Printers: new "Print devices / keys" panel:
+  - Create key dialog (choose outlet, device id, name) → **show full key once** with copy button + warning.
+  - Key list: masked key, name, device, last seen, revoked badge; revoke action.
+  - Device online badge now driven by hub event (subscribe via existing `stores/hub.svelte.ts` `RefreshOutlet`/device-status event) instead of page-load-only `isConnected`.
+- Regenerate orval client (`client/orval.config.ts`) for the new `PrintServiceKey` endpoints.
+
+## Phases
+
+| Phase | Scope | Deployable? |
+|---|---|---|
+| **1. Keys + hub** | `PrintServiceKey` entity+migration, CRUD endpoints, `PrinterKeyAuthenticationHandler`, `PrinterHub`, connection tracker | Yes — additive, nothing uses it yet |
+| **2. Client UI** | Key management + device status panel, regenerated API client | Yes |
+| **3. print-service v2** | SignalR client, config change, Redis removal | Ships to Pis; talks to Phase 1 API |
+| **4. Cutover** | API flag `both` → upgrade Pis → flag `signalr` → **5. Cleanup** | |
+| **5. Cleanup** | Delete Redis publish path, `PUBSUB` status logic, Redis keys contract; delete print-service Redis packages | Final |
+
+Rollback: flip `Print:Transport` back to `redis` while old print-service images are still running (keep the Redis path until every Pi is upgraded).
+
+## Cross-platform & deployment (Go option)
+
+Nothing in the hub/API design is platform-specific: SignalR is HTTP/WebSockets + a documented JSON protocol, device identity is the API key (outlet + device), never the host. The only host-specific concerns are the nmap binary and how the service is launched.
+
+**Build matrix** — one codebase, static binaries (`CGO_ENABLED=0`):
+
+| Target | Flags | Notes |
+|---|---|---|
+| Pi Zero 1 (W) | `GOOS=linux GOARCH=arm GOARM=6` | ARMv6 — .NET cannot target this at all |
+| Pi Zero 2 W / Pi 4/5 / ARM servers | `GOOS=linux GOARCH=arm64` | |
+| x86 servers / Docker | `GOOS=linux GOARCH=amd64` | |
+| Windows box (if ever) | `GOOS=windows GOARCH=amd64` | run as service via `x/sys/windows/svc` |
+
+Deploy as multi-arch Docker (`docker buildx --platform linux/amd64,linux/arm64,linux/arm/v6`, one `latest` tag, device pulls the right image) or bare systemd (`Restart=always`) on Pi OS.
+
+**Printer path** is pure TCP to raw port 9100 (JetDirect) — no CUPS/spooler/driver on any OS. The one future boundary: USB/serial printers would introduce OS-specific device handling (out of scope).
+
+**Drop nmap** (recommended if Go): replace with a native Go TCP-connect scan (`net.Dialer` + goroutines over the subnet, 300ms timeout). Faster for "which IPs have 9100 open", needs no root (unlike nmap SYN scans), and removes the only external binary → `FROM scratch` images. Trade-off: `PrinterScan.svelte` shows raw nmap output today; switch to a structured typed result.
+
+**Wire-level concerns (protocol, not OS):** JSON hub protocol camelCase ↔ Go struct tags; .NET `byte[]` ↔ base64 ↔ Go `[]byte` (natively compatible). Verify once against the live hub in an integration test.
+
+**Staying on .NET instead:** cross-platform via self-contained RIDs (`linux-arm64`, `win-x64`); fine on Pi Zero 2 W+, x86, Windows — but no ARMv6 support and ~70–100MB on disk / RSS on 512MB devices.
+
+## Security checklist
+
+- Secret stored **hashed only**; plaintext shown once; high-entropy random (≥128 bits).
+- Key binds outlet + device; group membership derived **only** from validated claims server-side.
+- Separate hub + scheme so device keys can never hit user-only `KayordHub` features.
+- TLS enforced in production (public endpoint); hub auth also accepts header bearer for non-browser clients.
+- Revocation is immediate for new connections; ≤5 min for cached validations (acceptable for printer hardware; can be made immediate by clearing the cache entry on revoke).
+- `LastSeenAt` enables auditing/stale-key cleanup job later (optional TickerQ task).
+- nmap action: keep it restricted — server only sends `Action: "nmap"` from the authenticated `/printer/scan` endpoint; device should ignore unknown actions (already the case).


### PR DESCRIPTION
## What

Two agent-facing implementation guides for migrating the print pipeline from Redis pub/sub to SignalR:

- **`docs/Print.md`** — this repo (Pos.Api + Svelte client): `PrintServiceKey` entity + EF migration, manager-only key management endpoints (`kpos_{keyId}.{secret}`, hashed, shown once), `PrinterKey` auth handler, new `/printer-hub` (`PrinterHub`) with server-side group joins, dual-transport send switch (`Print:Transport: redis|both|signalr` — Redis path preserved until all printer boxes are migrated), admin UI for keys + new printer states (`DeviceOnline`, `PrinterReachable`) with live badge updates.
- **`docs/Print-service.md`** — the replacement Go print service: outbound-only SignalR client (`philippseith/signalr`), raw TCP printing (no ESC/POS lib — server pre-renders bytes), native Go subnet scan replacing nmap, printer reachability probes, static multi-arch builds (linux/armv6 incl. Pi Zero 1, arm64, amd64), Docker `FROM scratch` + systemd deploy.
- `docs/print-service-signalr-migration.md` — previous planning doc, now banner-marked as background/rationale.

Both guides are self-contained with phase checklists, exact file paths, wire contracts (mirrored across docs), verification steps, and acceptance criteria so another AI agent can execute them.

## Notes

- PR is based on `aspire` (this branch was cut from `origin/aspire`); docs-only change, zero runtime impact.
- Default `Print:Transport=redis` keeps current behavior — nothing changes until ops flips the flag during per-box cutover.